### PR TITLE
Fix crash in librato_reporter when there's a network connection failure

### DIFF
--- a/librato_reporter.go
+++ b/librato_reporter.go
@@ -56,6 +56,11 @@ func (self *LibratoReporter) ReportHealth(h *Health) {
 	req.Header.Set("User-Agent", libratoReporterUA)
 	req.SetBasicAuth(self.Credentials.User, self.Credentials.Key)
 	resp, err := http.DefaultClient.Do(req)
+	
+	if nil != err {
+		log.Println("Error receiving response", err)
+		return
+	}
 
 	if resp.StatusCode != 200 {
 		log.Println("Error: Librato API Error: ", resp)


### PR DESCRIPTION
When a network error occurs between the machine being monitored and the Librato service, the response becomes nil which causes the check of the response status code at resp.StatusCode to crash the program on a nil pointer.

This change adds an additional check after the response is retrieved which checks for an error and prevents further execution if one is detected, in the same way that the request creation error checks work further up in the logic.

An example of the kind of error that could occur, causing the response to not be created and the program to crash is:
2013/06/07 01:34:34 Error getting response Post https://metrics-api.librato.com/v1/metrics: read tcp 184.73.208.157:443: no route to host
panic: runtime error: invalid memory address or nil pointer dereference
