### PR TITLE
Corrected graphite output with unix timestamp

### DIFF
--- a/graphite_reporter.go
+++ b/graphite_reporter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 )
 
 type GraphiteReporter struct {
@@ -17,8 +18,11 @@ func NewGraphiteReporter(conf GraphiteConfig) (h *GraphiteReporter) {
 func (self *GraphiteReporter) ReportHealth(h *Health) {
 	hmap := h.Map()
 	data := ""
+	now := time.Now()
+	ts := now.Unix()
+
 	for k, v := range hmap {
-		data += fmt.Sprintf("%s%s%s %v\n", self.Config.Prefix, k, self.Config.Postfix, v)
+		data += fmt.Sprintf("%s%s%s %v %v\n", self.Config.Prefix, k, self.Config.Postfix, v, ts)
 	}
 
 	addr, err := net.ResolveTCPAddr("tcp", self.Config.LineRec)

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		reporters = append(reporters, NewStdoutReporter())
 	}
 
-	log.Println("Lauching Health")
+	log.Println("Launching Health")
 
 	report(config, &reporters)
 


### PR DESCRIPTION
Corrected the graphite reporter to include the time stamp in unix epoch time as per the [graphite documentation](http://graphite.readthedocs.org/en/0.9.10/feeding-carbon.html#the-plaintext-protocol):

```
<metric path> <metric value> <metric timestamp>
```
